### PR TITLE
Update public_suffix_list.dat

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -10703,6 +10703,12 @@ cc.ua
 inf.ua
 ltd.ua
 
+// activo systems s.r.o. : https://www.uplink.cz/
+// Submited by Michal Krajcirovic <michal@uplink.cz>
+6r.cz
+6s.cz
+e-shop.cz
+
 // Agnat sp. z o.o. : https://domena.pl
 // Submitted by Przemyslaw Plewa <it-admin@domena.pl>
 beep.pl


### PR DESCRIPTION
Domains: 6r.cz, 6s.cz, e-shop.cz

<!-- #### READ THIS FIRST ####

If you haven't yet, please read our guidelines:
https://github.com/publicsuffix/list/wiki/Guidelines#submit-the-change

If you'd like an example of what an excellent PR looks like
see https://github.com/publicsuffix/list/pull/615
-->

* [x] Description of Organization
* [x] Reason for PSL Inclusion
* [x] DNS Verification via dig
* [x] make test

Description of Organization
====
activo systems s.r.o. (known as UPLINK.CZ) is stable Czech Republic webhosting/serverhosting provider since 2008, member of Fiber Telecom (Ltd) group. 

Reason for PSL Inclusion
====
We provide for our clients domains for their vps/hostings to testing and temporary usage. We now working on public dyndns service and free-hosting on short domains 6r.cz, 6s.cz and subdomains registrar on e-shop.cz domain, for ecommerce business, where we need have option to delegate NS records for other webhosting companies to use "our" subdomain hosting everywhere.

DNS Verification via dig
=======
```
# dig +short TXT _psl.6r.cz
"https://github.com/publicsuffix/list/pull/734"

# dig +short TXT _psl.6s.cz
"https://github.com/publicsuffix/list/pull/734"

# dig +short TXT _psl.e-shop.cz
"https://github.com/publicsuffix/list/pull/734"
```

make test
=========
`make test` completed successfully.

